### PR TITLE
Fixed getTypes for types without argument data

### DIFF
--- a/SharpOSC/OscPacket.cs
+++ b/SharpOSC/OscPacket.cs
@@ -238,7 +238,7 @@ namespace SharpOSC
 			int i = index + 4;
 			char[] types = null;
 
-			for (; i < msg.Length; i += 4)
+			for (; i <= msg.Length; i += 4)
 			{
 				if (msg[i - 1] == 0)
 				{


### PR DESCRIPTION
When using types without argument data, e.g. Bools, the message end with the type. Since no byte follows, msg.Length is index + 4 in this case and getTypes needs to check i <= msg.Length and not i < msg.Length